### PR TITLE
사용자 회원가입 추가 정보 및 내 정보 확인 구현

### DIFF
--- a/src/main/java/ohho/backend/spring/config/security/PreAuthTokenProvider.java
+++ b/src/main/java/ohho/backend/spring/config/security/PreAuthTokenProvider.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 import ohho.backend.spring.config.jwt.JwtService;
 import ohho.backend.spring.config.security.exception.TokenMissingException;
 import ohho.backend.spring.domain.member.entities.Member;
-import ohho.backend.spring.domain.member.service.MemberService;
 
+import ohho.backend.spring.domain.member.service.MemberService;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -26,10 +26,10 @@ public class PreAuthTokenProvider implements AuthenticationProvider {
         if (authentication instanceof PreAuthenticatedAuthenticationToken) {
             String token = authentication.getPrincipal().toString();
             Long memberId = jwtService.decode(token);
-            // TODO: 지원자 조회 실패하는 경우, AuthenticationException 으로 예외번역
-            Member applicant = memberService.getMember(memberId);
+            // TODO: 멤버 조회 실패하는 경우, AuthenticationException 으로 예외번역
+            Member member = memberService.getMember(memberId);
             return new PreAuthenticatedAuthenticationToken(
-                applicant.getId(),
+                member.getId(),
                 "",
                 Collections.singletonList(
                     new SimpleGrantedAuthority(SecurityConfig.MEMBER_ROLE_NAME))

--- a/src/main/java/ohho/backend/spring/config/security/SecurityConfig.java
+++ b/src/main/java/ohho/backend/spring/config/security/SecurityConfig.java
@@ -6,8 +6,9 @@ import lombok.RequiredArgsConstructor;
 import ohho.backend.spring.common.ResultCode;
 import ohho.backend.spring.common.response.ApiResponse;
 import ohho.backend.spring.config.jwt.JwtService;
-import ohho.backend.spring.domain.member.service.MemberService;
+import ohho.backend.spring.domain.member.repository.MemberRepository;
 
+import ohho.backend.spring.domain.member.service.MemberService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/ohho/backend/spring/domain/member/controller/MemberController.java
+++ b/src/main/java/ohho/backend/spring/domain/member/controller/MemberController.java
@@ -2,11 +2,15 @@ package ohho.backend.spring.domain.member.controller;
 
 import lombok.RequiredArgsConstructor;
 import ohho.backend.spring.common.response.ApiResponse;
+import ohho.backend.spring.domain.member.entities.Member;
 import ohho.backend.spring.domain.member.model.request.SignInRequestDto;
 import ohho.backend.spring.domain.member.model.request.SignUpRequestDto;
+import ohho.backend.spring.domain.member.model.response.GetMyInfoResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignInResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignUpResponseDto;
 import ohho.backend.spring.domain.member.service.MemberService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,4 +33,9 @@ public class MemberController {
         return ApiResponse.success(memberService.signIn(signInRequestDto));
     }
 
+    @GetMapping("/me")
+    public ApiResponse<GetMyInfoResponseDto> getMyInfo(
+        @ModelAttribute("memberId") Long memberId) {
+        return ApiResponse.success(memberService.getMyInfo(memberId));
+    }
 }

--- a/src/main/java/ohho/backend/spring/domain/member/entities/Member.java
+++ b/src/main/java/ohho/backend/spring/domain/member/entities/Member.java
@@ -3,13 +3,21 @@ package ohho.backend.spring.domain.member.entities;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.Getter;
 import ohho.backend.spring.common.entities.BaseEntity;
+import ohho.backend.spring.domain.exercise.enums.converter.ExerciseTypeConverter;
 import ohho.backend.spring.domain.exerciseHistory.entities.ExerciseHistory;
+import ohho.backend.spring.domain.member.enums.Age;
+import ohho.backend.spring.domain.member.enums.Gender;
+import ohho.backend.spring.domain.member.enums.converter.AgeConverter;
+import ohho.backend.spring.domain.member.enums.converter.GenderConverter;
 import ohho.backend.spring.domain.organization.entities.Organization;
 import ohho.backend.spring.domain.partner.entities.Partner;
 
@@ -24,6 +32,12 @@ public class Member extends BaseEntity {
     private String nickName;
 
     private String interestList;
+
+    @Convert(converter = GenderConverter.class)
+    private Gender gender;
+
+    @Convert(converter = AgeConverter.class)
+    private Age age;
 
     /* 연관관계 */
 

--- a/src/main/java/ohho/backend/spring/domain/member/entities/Member.java
+++ b/src/main/java/ohho/backend/spring/domain/member/entities/Member.java
@@ -26,7 +26,7 @@ public class Member extends BaseEntity {
 
     private String password;
 
-    private String nickName;
+    private String nickname;
 
     private String interestList;
 
@@ -50,13 +50,13 @@ public class Member extends BaseEntity {
     protected Member() {
     }
 
-    public static Member of(String email, String password, String nickName,
+    public static Member of(String email, String password, String nickname,
         String gender, String age) {
 
         Member member = new Member();
         member.email = email;
         member.password = password;
-        member.nickName = nickName;
+        member.nickname = nickname;
         member.gender = Gender.ofGender(gender);
         member.age = Age.ofAge(age);
         return member;

--- a/src/main/java/ohho/backend/spring/domain/member/entities/Member.java
+++ b/src/main/java/ohho/backend/spring/domain/member/entities/Member.java
@@ -5,14 +5,11 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.Getter;
 import ohho.backend.spring.common.entities.BaseEntity;
-import ohho.backend.spring.domain.exercise.enums.converter.ExerciseTypeConverter;
 import ohho.backend.spring.domain.exerciseHistory.entities.ExerciseHistory;
 import ohho.backend.spring.domain.member.enums.Age;
 import ohho.backend.spring.domain.member.enums.Gender;
@@ -53,11 +50,15 @@ public class Member extends BaseEntity {
     protected Member() {
     }
 
-    public static Member of(String email, String password, String nickName) {
+    public static Member of(String email, String password, String nickName,
+        String gender, String age) {
+
         Member member = new Member();
         member.email = email;
         member.password = password;
         member.nickName = nickName;
+        member.gender = Gender.ofGender(gender);
+        member.age = Age.ofAge(age);
         return member;
     }
 }

--- a/src/main/java/ohho/backend/spring/domain/member/enums/Age.java
+++ b/src/main/java/ohho/backend/spring/domain/member/enums/Age.java
@@ -6,25 +6,25 @@ import lombok.Getter;
 
 @Getter
 public enum Age {
-    TEN("10", "10대"),
-    TWENTY("20", "20대"),
-    Thirty("30", "30대"),
-    FORTY("40", "40대"),
-    FIFTY("50", "50대"),
-    SIXTY("60", "60대");
+    TEN("10대", "10"),
+    TWENTY("20대", "20"),
+    Thirty("30대", "30"),
+    FORTY("40대", "40"),
+    FIFTY("50대", "50"),
+    SIXTY("60대", "60");
 
-    final String age;
     final String value;
+    final String code;
 
-    Age(String age, String value) {
-        this.age = age;
+    Age(String value, String code) {
         this.value = value;
+        this.code = code;
     }
 
-    public static Age ofAge(String value) {
+    public static Age ofAge(String code) {
 
         return Arrays.stream(Age.values())
-            .filter(v -> v.getValue().equals(value))
+            .filter(v -> v.getCode().equals(code))
             .findAny()
             .orElseThrow(NoSuchElementException::new);
     }

--- a/src/main/java/ohho/backend/spring/domain/member/enums/Age.java
+++ b/src/main/java/ohho/backend/spring/domain/member/enums/Age.java
@@ -6,18 +6,18 @@ import lombok.Getter;
 
 @Getter
 public enum Age {
-    TEN("10", "TEN"),
-    TWENTY("20", "TWENTY"),
-    Thirty("30", "Thirty"),
-    FORTY("40", "FORTY"),
-    FIFTY("50", "FIFTY"),
-    SIXTY("60", "SIXTY");
+    TEN("10", "10대"),
+    TWENTY("20", "20대"),
+    Thirty("30", "30대"),
+    FORTY("40", "40대"),
+    FIFTY("50", "50대"),
+    SIXTY("60", "60대");
 
-    final String number;
+    final String age;
     final String value;
 
-    Age(String number, String value) {
-        this.number = number;
+    Age(String age, String value) {
+        this.age = age;
         this.value = value;
     }
 

--- a/src/main/java/ohho/backend/spring/domain/member/enums/Age.java
+++ b/src/main/java/ohho/backend/spring/domain/member/enums/Age.java
@@ -1,0 +1,31 @@
+package ohho.backend.spring.domain.member.enums;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import lombok.Getter;
+
+@Getter
+public enum Age {
+    TEN("10", "TEN"),
+    TWENTY("20", "TWENTY"),
+    Thirty("30", "Thirty"),
+    FORTY("40", "FORTY"),
+    FIFTY("50", "FIFTY"),
+    SIXTY("60", "SIXTY");
+
+    final String number;
+    final String value;
+
+    Age(String number, String value) {
+        this.number = number;
+        this.value = value;
+    }
+
+    public static Age ofAge(String value) {
+
+        return Arrays.stream(Age.values())
+            .filter(v -> v.getValue().equals(value))
+            .findAny()
+            .orElseThrow(NoSuchElementException::new);
+    }
+}

--- a/src/main/java/ohho/backend/spring/domain/member/enums/Gender.java
+++ b/src/main/java/ohho/backend/spring/domain/member/enums/Gender.java
@@ -6,21 +6,21 @@ import lombok.Getter;
 
 @Getter
 public enum Gender {
-    WOMAN("W", "여성"),
-    MAN("M", "남성");
+    WOMAN("여성", "W"),
+    MAN("남성", "M");
 
-    final String code;
     final String value;
+    final String code;
 
-    Gender(String code, String value) {
-        this.code = code;
+    Gender(String value, String code) {
         this.value = value;
+        this.code = code;
     }
 
-    public static Gender ofGender(String value) {
+    public static Gender ofGender(String code) {
 
         return Arrays.stream(Gender.values())
-            .filter(v -> v.getValue().equals(value))
+            .filter(v -> v.getCode().equals(code))
             .findAny()
             .orElseThrow(NoSuchElementException::new);
     }

--- a/src/main/java/ohho/backend/spring/domain/member/enums/Gender.java
+++ b/src/main/java/ohho/backend/spring/domain/member/enums/Gender.java
@@ -17,10 +17,10 @@ public enum Gender {
         this.value = value;
     }
 
-    public static Gender ofGender(String name) {
+    public static Gender ofGender(String value) {
 
         return Arrays.stream(Gender.values())
-            .filter(v -> v.getValue().equals(name))
+            .filter(v -> v.getValue().equals(value))
             .findAny()
             .orElseThrow(NoSuchElementException::new);
     }

--- a/src/main/java/ohho/backend/spring/domain/member/enums/Gender.java
+++ b/src/main/java/ohho/backend/spring/domain/member/enums/Gender.java
@@ -1,0 +1,27 @@
+package ohho.backend.spring.domain.member.enums;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import lombok.Getter;
+
+@Getter
+public enum Gender {
+    WOMAN("W", "여성"),
+    MAN("M", "남성");
+
+    final String code;
+    final String value;
+
+    Gender(String code, String value) {
+        this.code = code;
+        this.value = value;
+    }
+
+    public static Gender ofGender(String name) {
+
+        return Arrays.stream(Gender.values())
+            .filter(v -> v.getValue().equals(name))
+            .findAny()
+            .orElseThrow(NoSuchElementException::new);
+    }
+}

--- a/src/main/java/ohho/backend/spring/domain/member/enums/converter/AgeConverter.java
+++ b/src/main/java/ohho/backend/spring/domain/member/enums/converter/AgeConverter.java
@@ -1,0 +1,17 @@
+package ohho.backend.spring.domain.member.enums.converter;
+
+import javax.persistence.AttributeConverter;
+import ohho.backend.spring.domain.member.enums.Age;
+
+public class AgeConverter implements AttributeConverter<Age, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Age attribute) {
+        return attribute.getNumber();
+    }
+
+    @Override
+    public Age convertToEntityAttribute(String dbData) {
+        return Age.ofAge(dbData);
+    }
+}

--- a/src/main/java/ohho/backend/spring/domain/member/enums/converter/AgeConverter.java
+++ b/src/main/java/ohho/backend/spring/domain/member/enums/converter/AgeConverter.java
@@ -7,7 +7,7 @@ public class AgeConverter implements AttributeConverter<Age, String> {
 
     @Override
     public String convertToDatabaseColumn(Age attribute) {
-        return attribute.getNumber();
+        return attribute.getAge();
     }
 
     @Override

--- a/src/main/java/ohho/backend/spring/domain/member/enums/converter/AgeConverter.java
+++ b/src/main/java/ohho/backend/spring/domain/member/enums/converter/AgeConverter.java
@@ -7,7 +7,7 @@ public class AgeConverter implements AttributeConverter<Age, String> {
 
     @Override
     public String convertToDatabaseColumn(Age attribute) {
-        return attribute.getAge();
+        return attribute.getCode();
     }
 
     @Override

--- a/src/main/java/ohho/backend/spring/domain/member/enums/converter/GenderConverter.java
+++ b/src/main/java/ohho/backend/spring/domain/member/enums/converter/GenderConverter.java
@@ -1,0 +1,18 @@
+package ohho.backend.spring.domain.member.enums.converter;
+
+import javax.persistence.AttributeConverter;
+import ohho.backend.spring.domain.exercise.enums.ExerciseType;
+import ohho.backend.spring.domain.member.enums.Gender;
+
+public class GenderConverter implements AttributeConverter<Gender, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Gender attribute) {
+        return attribute.getValue();
+    }
+
+    @Override
+    public Gender convertToEntityAttribute(String dbData) {
+        return Gender.ofGender(dbData);
+    }
+}

--- a/src/main/java/ohho/backend/spring/domain/member/enums/converter/GenderConverter.java
+++ b/src/main/java/ohho/backend/spring/domain/member/enums/converter/GenderConverter.java
@@ -8,7 +8,7 @@ public class GenderConverter implements AttributeConverter<Gender, String> {
 
     @Override
     public String convertToDatabaseColumn(Gender attribute) {
-        return attribute.getValue();
+        return attribute.getCode();
     }
 
     @Override

--- a/src/main/java/ohho/backend/spring/domain/member/exception/MemberSignUpRequestInvalidException.java
+++ b/src/main/java/ohho/backend/spring/domain/member/exception/MemberSignUpRequestInvalidException.java
@@ -1,8 +1,11 @@
 package ohho.backend.spring.domain.member.exception;
 
-public class MemberSignUpRequestInvalidException extends RuntimeException {
+import ohho.backend.spring.common.ResultCode;
+import ohho.backend.spring.common.exception.BadRequestException;
+
+public class MemberSignUpRequestInvalidException extends BadRequestException {
 
     public MemberSignUpRequestInvalidException(String message) {
-        super(message);
+        super(ResultCode.BAD_REQUEST, message);
     }
 }

--- a/src/main/java/ohho/backend/spring/domain/member/model/request/SignUpRequestDto.java
+++ b/src/main/java/ohho/backend/spring/domain/member/model/request/SignUpRequestDto.java
@@ -2,6 +2,8 @@ package ohho.backend.spring.domain.member.model.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import ohho.backend.spring.domain.member.enums.Age;
+import ohho.backend.spring.domain.member.enums.Gender;
 
 @Data
 @AllArgsConstructor
@@ -10,5 +12,7 @@ public class SignUpRequestDto {
     String email;
     String nickname;
     String password;
+    String gender;
+    String age;
     // TODO: 관심 있는 운동 추가로 입력
 }

--- a/src/main/java/ohho/backend/spring/domain/member/model/response/GetMyInfoResponseDto.java
+++ b/src/main/java/ohho/backend/spring/domain/member/model/response/GetMyInfoResponseDto.java
@@ -1,0 +1,20 @@
+package ohho.backend.spring.domain.member.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import ohho.backend.spring.domain.member.enums.Age;
+import ohho.backend.spring.domain.member.enums.Gender;
+
+@Data
+@AllArgsConstructor
+public class GetMyInfoResponseDto {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private String interestList;
+    private Gender gender;
+    private Age age;
+
+    // TODO: partner, organization, exerciseHistories 추가
+}

--- a/src/main/java/ohho/backend/spring/domain/member/repository/MemberRepository.java
+++ b/src/main/java/ohho/backend/spring/domain/member/repository/MemberRepository.java
@@ -12,5 +12,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
-    boolean existsByNickName(String nickname);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/ohho/backend/spring/domain/member/service/MemberService.java
+++ b/src/main/java/ohho/backend/spring/domain/member/service/MemberService.java
@@ -9,6 +9,8 @@ import ohho.backend.spring.domain.member.model.response.SignUpResponseDto;
 
 public interface MemberService {
 
+    Member getMember(Long memberId);
+
     GetMyInfoResponseDto getMyInfo(Long memberId);
 
     SignUpResponseDto signUp(SignUpRequestDto signUpRequestDto);

--- a/src/main/java/ohho/backend/spring/domain/member/service/MemberService.java
+++ b/src/main/java/ohho/backend/spring/domain/member/service/MemberService.java
@@ -3,12 +3,13 @@ package ohho.backend.spring.domain.member.service;
 import ohho.backend.spring.domain.member.entities.Member;
 import ohho.backend.spring.domain.member.model.request.SignInRequestDto;
 import ohho.backend.spring.domain.member.model.request.SignUpRequestDto;
+import ohho.backend.spring.domain.member.model.response.GetMyInfoResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignInResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignUpResponseDto;
 
 public interface MemberService {
 
-    Member getMember(Long memberId);
+    GetMyInfoResponseDto getMyInfo(Long memberId);
 
     SignUpResponseDto signUp(SignUpRequestDto signUpRequestDto);
 

--- a/src/main/java/ohho/backend/spring/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/ohho/backend/spring/domain/member/service/MemberServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import ohho.backend.spring.config.jwt.JwtService;
 import ohho.backend.spring.domain.member.entities.Member;
+import ohho.backend.spring.domain.member.enums.Gender;
 import ohho.backend.spring.domain.member.exception.MemberNicknameAlreadyExistException;
 import ohho.backend.spring.domain.member.exception.MemberNotFoundException;
 import ohho.backend.spring.domain.member.exception.MemberEmailDuplicatedException;
@@ -37,7 +38,9 @@ public class MemberServiceImpl implements MemberService {
         Member member = Member.of(
             signUpRequestDto.getEmail(),
             passwordEncoder.encode(signUpRequestDto.getPassword()),
-            signUpRequestDto.getNickname()
+            signUpRequestDto.getNickname(),
+            signUpRequestDto.getGender(),
+            signUpRequestDto.getAge()
         );
         memberRepository.save(member);
 

--- a/src/main/java/ohho/backend/spring/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/ohho/backend/spring/domain/member/service/MemberServiceImpl.java
@@ -97,4 +97,10 @@ public class MemberServiceImpl implements MemberService {
         return new GetMyInfoResponseDto(member.getId(), member.getEmail(), member.getNickname(),
             member.getInterestList(), member.getGender(), member.getAge());
     }
+
+    @Override
+    public Member getMember(Long memberId) {
+        Assert.notNull(memberId, "'memberId' must not be null");
+        return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    }
 }

--- a/src/main/java/ohho/backend/spring/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/ohho/backend/spring/domain/member/service/MemberServiceImpl.java
@@ -11,6 +11,7 @@ import ohho.backend.spring.domain.member.exception.MemberEmailDuplicatedExceptio
 import ohho.backend.spring.domain.member.exception.MemberSignUpRequestInvalidException;
 import ohho.backend.spring.domain.member.model.request.SignInRequestDto;
 import ohho.backend.spring.domain.member.model.request.SignUpRequestDto;
+import ohho.backend.spring.domain.member.model.response.GetMyInfoResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignInResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignUpResponseDto;
 import ohho.backend.spring.domain.member.repository.MemberRepository;
@@ -66,7 +67,7 @@ public class MemberServiceImpl implements MemberService {
             throw new MemberEmailDuplicatedException(
                 "이미 사용중인 email 입니다. email: " + signUpRequestDto.getEmail());
         }
-        if (memberRepository.existsByNickName(signUpRequestDto.getNickname())) {
+        if (memberRepository.existsByNickname(signUpRequestDto.getNickname())) {
             throw new MemberNicknameAlreadyExistException(
                 "이미 사용중인 nickname 입니다. nickname: " + signUpRequestDto.getNickname());
         }
@@ -88,8 +89,12 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public Member getMember(Long memberId) {
+    public GetMyInfoResponseDto getMyInfo(Long memberId) {
         Assert.notNull(memberId, "'memberId' must not be null");
-        return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(MemberNotFoundException::new);
+
+        return new GetMyInfoResponseDto(member.getId(), member.getEmail(), member.getNickname(),
+            member.getInterestList(), member.getGender(), member.getAge());
     }
 }


### PR DESCRIPTION
## 변경사항

### 회원가입 시, 추가 정보 입력
- 사용자의 성별 및 나이 추가 입력
- enum converter 생성

### 내 정보 확인 구현
- `access token`으로 멤버를 조회합니다.
- 멤버의 `id`, `email`, `nickname`, `interestList`, `gender`, `age`를 반환합니다.
