### PR TITLE
파트너 요청 및 디데이, 목표 설정 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,33 @@ plugins {
     id 'org.springframework.boot' version '2.6.3'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'ohho.backend'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
+
+def querydslDir = "$buildDir/generated/querydsl" as Object
+querydsl {
+    library = "com.querydsl:querydsl-apt"
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/main/java', querydslDir]
+        }
+    }
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
 
 configurations {
     compileOnly {
@@ -40,6 +62,10 @@ dependencies {
 
     /* 마이그레이션 및 시드파일 관련 */
     implementation "org.flywaydb:flyway-core:$flywaydbVersion"
+
+    /* querydsl 관련 */
+    implementation 'com.querydsl:querydsl-jpa'
+    implementation 'com.querydsl:querydsl-apt'
 }
 
 tasks.named('test') {

--- a/src/main/java/ohho/backend/spring/common/ResultCode.java
+++ b/src/main/java/ohho/backend/spring/common/ResultCode.java
@@ -12,7 +12,10 @@ public enum ResultCode {
 
     // member (사용자)
     MEMBER_NOT_FOUND("사용자가 존재하지 않습니다."),
-    MEMBER_NICKNAME_ALREADY_EXIST("이미 존재하는 닉네임입니다.");
+    MEMBER_NICKNAME_ALREADY_EXIST("이미 존재하는 닉네임입니다."),
+
+    // partner (파트너)
+    PARTNER_NOT_FOUND("파트너가 존재하지 않습니다.");
 
     private final String message;
 

--- a/src/main/java/ohho/backend/spring/common/utils/LocalDateTimeToArray.java
+++ b/src/main/java/ohho/backend/spring/common/utils/LocalDateTimeToArray.java
@@ -1,0 +1,23 @@
+package ohho.backend.spring.common.utils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+
+public class LocalDateTimeToArray {
+
+    private LocalDateTimeToArray() {
+    }
+
+    public static Integer[] convert(LocalDateTime localDateTime) {
+        if (localDateTime == null) {
+            return new Integer[3];
+        }
+        String dateString = localDateTime.format(DateTimeFormatter.ISO_DATE);
+
+        return Arrays.stream(dateString.split("-"))
+            .map(Integer::valueOf)
+            .toArray(Integer[]::new);
+    }
+}
+

--- a/src/main/java/ohho/backend/spring/domain/member/controller/MemberController.java
+++ b/src/main/java/ohho/backend/spring/domain/member/controller/MemberController.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import ohho.backend.spring.common.ApiResponse;
 import ohho.backend.spring.domain.member.model.request.SignInRequestDto;
 import ohho.backend.spring.domain.member.model.request.SignUpRequestDto;
-import ohho.backend.spring.domain.member.model.response.GetMemberByNicknameDto;
+import ohho.backend.spring.domain.member.model.response.GetMemberByNicknameResponseDto;
 import ohho.backend.spring.domain.member.model.response.GetMyInfoResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignInResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignUpResponseDto;
@@ -41,7 +41,7 @@ public class MemberController {
     }
 
     @GetMapping("/nickname/{nickname}")
-    public ApiResponse<GetMemberByNicknameDto> searchMemberByNickname(
+    public ApiResponse<GetMemberByNicknameResponseDto> searchMemberByNickname(
         @PathVariable("nickname") String nickname) {
         return ApiResponse.success(memberService.getMemberByNickname(nickname));
     }

--- a/src/main/java/ohho/backend/spring/domain/member/controller/MemberController.java
+++ b/src/main/java/ohho/backend/spring/domain/member/controller/MemberController.java
@@ -4,12 +4,14 @@ import lombok.RequiredArgsConstructor;
 import ohho.backend.spring.common.ApiResponse;
 import ohho.backend.spring.domain.member.model.request.SignInRequestDto;
 import ohho.backend.spring.domain.member.model.request.SignUpRequestDto;
+import ohho.backend.spring.domain.member.model.response.GetMemberByNicknameDto;
 import ohho.backend.spring.domain.member.model.response.GetMyInfoResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignInResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignUpResponseDto;
 import ohho.backend.spring.domain.member.service.MemberService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,5 +38,11 @@ public class MemberController {
     public ApiResponse<GetMyInfoResponseDto> getMyInfo(
         @ModelAttribute("memberId") Long memberId) {
         return ApiResponse.success(memberService.getMyInfo(memberId));
+    }
+
+    @GetMapping("/nickname/{nickname}")
+    public ApiResponse<GetMemberByNicknameDto> searchMemberByNickname(
+        @PathVariable("nickname") String nickname) {
+        return ApiResponse.success(memberService.getMemberByNickname(nickname));
     }
 }

--- a/src/main/java/ohho/backend/spring/domain/member/model/response/GetMemberByNicknameDto.java
+++ b/src/main/java/ohho/backend/spring/domain/member/model/response/GetMemberByNicknameDto.java
@@ -1,0 +1,12 @@
+package ohho.backend.spring.domain.member.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GetMemberByNicknameDto {
+
+    private Long id;
+    private String nickname;
+}

--- a/src/main/java/ohho/backend/spring/domain/member/model/response/GetMemberByNicknameResponseDto.java
+++ b/src/main/java/ohho/backend/spring/domain/member/model/response/GetMemberByNicknameResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class GetMemberByNicknameDto {
+public class GetMemberByNicknameResponseDto {
 
     private Long id;
     private String nickname;

--- a/src/main/java/ohho/backend/spring/domain/member/repository/MemberRepository.java
+++ b/src/main/java/ohho/backend/spring/domain/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package ohho.backend.spring.domain.member.repository;
 
+import java.util.List;
 import java.util.Optional;
 import ohho.backend.spring.domain.member.entities.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByEmailAndPassword(String email, String password);
+
+    Optional<Member> findByNickname(String nickname);
 
     boolean existsByEmail(String email);
 

--- a/src/main/java/ohho/backend/spring/domain/member/service/MemberService.java
+++ b/src/main/java/ohho/backend/spring/domain/member/service/MemberService.java
@@ -4,12 +4,15 @@ import ohho.backend.spring.domain.member.entities.Member;
 import ohho.backend.spring.domain.member.model.request.SignInRequestDto;
 import ohho.backend.spring.domain.member.model.request.SignUpRequestDto;
 import ohho.backend.spring.domain.member.model.response.GetMyInfoResponseDto;
+import ohho.backend.spring.domain.member.model.response.GetMemberByNicknameDto;
 import ohho.backend.spring.domain.member.model.response.SignInResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignUpResponseDto;
 
 public interface MemberService {
 
     Member getMember(Long memberId);
+
+    GetMemberByNicknameDto getMemberByNickname(String nickname);
 
     GetMyInfoResponseDto getMyInfo(Long memberId);
 

--- a/src/main/java/ohho/backend/spring/domain/member/service/MemberService.java
+++ b/src/main/java/ohho/backend/spring/domain/member/service/MemberService.java
@@ -4,7 +4,7 @@ import ohho.backend.spring.domain.member.entities.Member;
 import ohho.backend.spring.domain.member.model.request.SignInRequestDto;
 import ohho.backend.spring.domain.member.model.request.SignUpRequestDto;
 import ohho.backend.spring.domain.member.model.response.GetMyInfoResponseDto;
-import ohho.backend.spring.domain.member.model.response.GetMemberByNicknameDto;
+import ohho.backend.spring.domain.member.model.response.GetMemberByNicknameResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignInResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignUpResponseDto;
 
@@ -12,7 +12,7 @@ public interface MemberService {
 
     Member getMember(Long memberId);
 
-    GetMemberByNicknameDto getMemberByNickname(String nickname);
+    GetMemberByNicknameResponseDto getMemberByNickname(String nickname);
 
     GetMyInfoResponseDto getMyInfo(Long memberId);
 

--- a/src/main/java/ohho/backend/spring/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/ohho/backend/spring/domain/member/service/MemberServiceImpl.java
@@ -10,7 +10,7 @@ import ohho.backend.spring.domain.member.exception.MemberSignUpRequestInvalidExc
 import ohho.backend.spring.domain.member.model.request.SignInRequestDto;
 import ohho.backend.spring.domain.member.model.request.SignUpRequestDto;
 import ohho.backend.spring.domain.member.model.response.GetMyInfoResponseDto;
-import ohho.backend.spring.domain.member.model.response.GetMemberByNicknameDto;
+import ohho.backend.spring.domain.member.model.response.GetMemberByNicknameResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignInResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignUpResponseDto;
 import ohho.backend.spring.domain.member.repository.MemberRepository;
@@ -102,10 +102,10 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public GetMemberByNicknameDto getMemberByNickname(String nickname) {
+    public GetMemberByNicknameResponseDto getMemberByNickname(String nickname) {
         Assert.notNull(nickname, "'nickname' must not be null");
         Member member = memberRepository.findByNickname(nickname)
             .orElseThrow(MemberNotFoundException::new);
-        return new GetMemberByNicknameDto(member.getId(), member.getNickname());
+        return new GetMemberByNicknameResponseDto(member.getId(), member.getNickname());
     }
 }

--- a/src/main/java/ohho/backend/spring/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/ohho/backend/spring/domain/member/service/MemberServiceImpl.java
@@ -1,6 +1,5 @@
 package ohho.backend.spring.domain.member.service;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import ohho.backend.spring.config.jwt.JwtService;
 import ohho.backend.spring.domain.member.entities.Member;
@@ -11,6 +10,7 @@ import ohho.backend.spring.domain.member.exception.MemberSignUpRequestInvalidExc
 import ohho.backend.spring.domain.member.model.request.SignInRequestDto;
 import ohho.backend.spring.domain.member.model.request.SignUpRequestDto;
 import ohho.backend.spring.domain.member.model.response.GetMyInfoResponseDto;
+import ohho.backend.spring.domain.member.model.response.GetMemberByNicknameDto;
 import ohho.backend.spring.domain.member.model.response.SignInResponseDto;
 import ohho.backend.spring.domain.member.model.response.SignUpResponseDto;
 import ohho.backend.spring.domain.member.repository.MemberRepository;
@@ -74,17 +74,15 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public SignInResponseDto signIn(SignInRequestDto signInRequestDto) {
-        Optional<Member> existingMember = memberRepository.findByEmail(signInRequestDto.getEmail());
-        if (!existingMember.isPresent()) {
-            throw new MemberNotFoundException();
-        }
+        Member existingMember = memberRepository.findByEmail(signInRequestDto.getEmail())
+            .orElseThrow(MemberNotFoundException::new);
 
         if (!passwordEncoder.matches(signInRequestDto.getPassword(),
-            existingMember.get().getPassword())) {
+            existingMember.getPassword())) {
             throw new MemberNotFoundException();
         }
 
-        return new SignInResponseDto(jwtService.encode(existingMember.get().getId()));
+        return new SignInResponseDto(jwtService.encode(existingMember.getId()));
     }
 
     @Override
@@ -101,5 +99,13 @@ public class MemberServiceImpl implements MemberService {
     public Member getMember(Long memberId) {
         Assert.notNull(memberId, "'memberId' must not be null");
         return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    }
+
+    @Override
+    public GetMemberByNicknameDto getMemberByNickname(String nickname) {
+        Assert.notNull(nickname, "'nickname' must not be null");
+        Member member = memberRepository.findByNickname(nickname)
+            .orElseThrow(MemberNotFoundException::new);
+        return new GetMemberByNicknameDto(member.getId(), member.getNickname());
     }
 }

--- a/src/main/java/ohho/backend/spring/domain/notification/controller/NotificationController.java
+++ b/src/main/java/ohho/backend/spring/domain/notification/controller/NotificationController.java
@@ -1,0 +1,39 @@
+package ohho.backend.spring.domain.notification.controller;
+
+import lombok.RequiredArgsConstructor;
+import ohho.backend.spring.common.ApiResponse;
+import ohho.backend.spring.domain.notification.service.NotificationService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    /* 로그인 한 멤버 sse 연결 */
+    @GetMapping(value = "/connection", produces = "text/event-stream")
+    public ApiResponse<SseEmitter> subscribe(@ModelAttribute("memberId") Long memberId,
+        @RequestParam(value = "lastEventId", required = false, defaultValue = "") String lastEventId) {
+        return ApiResponse.success(notificationService.subscribe(memberId, lastEventId));
+    }
+
+    /* 로그인 한 멤버의 모든 알림 조회 */
+//    @GetMapping("/notifications")
+//    public ResponseEntity<NotificationsResponse> notifications(@Login LoginMember loginMember) {
+//        return ResponseEntity.ok().body(notificationService.findAllById(loginMember));
+//    }
+
+    /* 알림 읽음 상태 변경 */
+//    @PatchMapping("/notifications/{id}")
+//    public ResponseEntity<Void> readNotification(@PathVariable Long id) {
+//        notificationService.readNotification(id);
+//        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+//    }
+}

--- a/src/main/java/ohho/backend/spring/domain/notification/entities/Notification.java
+++ b/src/main/java/ohho/backend/spring/domain/notification/entities/Notification.java
@@ -1,0 +1,21 @@
+package ohho.backend.spring.domain.notification.entities;
+
+import javax.persistence.Entity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ohho.backend.spring.common.entities.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Notification extends BaseEntity {
+
+    private Long senderId;
+
+    private Long receiverId;
+
+    public Notification(Long senderId, Long receiverId) {
+        this.senderId = senderId;
+        this.receiverId = receiverId;
+    }
+}

--- a/src/main/java/ohho/backend/spring/domain/notification/model/response/NotificationResponseDto.java
+++ b/src/main/java/ohho/backend/spring/domain/notification/model/response/NotificationResponseDto.java
@@ -1,0 +1,37 @@
+package ohho.backend.spring.domain.notification.model.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ohho.backend.spring.common.utils.LocalDateTimeToArray;
+import ohho.backend.spring.domain.notification.entities.Notification;
+
+@Getter
+@NoArgsConstructor
+public class NotificationResponseDto {
+
+    /**
+     * 알림 id
+     */
+    private Long id;
+
+    /**
+     * 알림이 생성된 날짜(몇일 전 계산 위함)
+     */
+    private Integer[] createdAt;
+
+    @Builder
+    public NotificationResponseDto(Long id, LocalDateTime createdAt) {
+        this.id = id;
+        this.createdAt = LocalDateTimeToArray.convert(createdAt);
+    }
+
+    public static NotificationResponseDto from(Notification notification) {
+        return NotificationResponseDto.builder()
+            .id(notification.getId())
+            .createdAt(notification.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/ohho/backend/spring/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/ohho/backend/spring/domain/notification/repository/EmitterRepository.java
@@ -1,0 +1,59 @@
+package ohho.backend.spring.domain.notification.repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class EmitterRepository {
+
+    public final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+    public SseEmitter save(String id, SseEmitter sseEmitter) {
+        emitters.put(id, sseEmitter);
+        return sseEmitter;
+    }
+
+    public void saveEventCache(String id, Object event) {
+        eventCache.put(id, event);
+    }
+
+    public Map<String, SseEmitter> findAllStartWithById(String id) {
+        return emitters.entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith(id))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public Map<String, Object> findAllEventCacheStartWithId(String id) {
+        return eventCache.entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith(id))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public void deleteAllStartWithId(String id) {
+        emitters.forEach(
+            (key, emitter) -> {
+                if (key.startsWith(id)) {
+                    emitters.remove(key);
+                }
+            }
+        );
+    }
+
+    public void deleteById(String id) {
+        emitters.remove(id);
+    }
+
+    public void deleteAllEventCacheStartWithId(String id) {
+        eventCache.forEach(
+            (key, data) -> {
+                if (key.startsWith(id)) {
+                    eventCache.remove(key);
+                }
+            }
+        );
+    }
+}

--- a/src/main/java/ohho/backend/spring/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/ohho/backend/spring/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package ohho.backend.spring.domain.notification.repository;
+
+import java.util.List;
+import ohho.backend.spring.domain.notification.entities.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findAllByReceiverId(Long id);
+}

--- a/src/main/java/ohho/backend/spring/domain/notification/service/NotificationService.java
+++ b/src/main/java/ohho/backend/spring/domain/notification/service/NotificationService.java
@@ -1,0 +1,10 @@
+package ohho.backend.spring.domain.notification.service;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface NotificationService {
+
+    SseEmitter subscribe(Long memberId, String lastEventId);
+
+    void send(Long senderId, Long receiverId);
+}

--- a/src/main/java/ohho/backend/spring/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/ohho/backend/spring/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,98 @@
+package ohho.backend.spring.domain.notification.service;
+
+import java.io.IOException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import ohho.backend.spring.domain.notification.entities.Notification;
+import ohho.backend.spring.domain.notification.model.response.NotificationResponseDto;
+import ohho.backend.spring.domain.notification.repository.EmitterRepository;
+import ohho.backend.spring.domain.notification.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(NotificationService.class);
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+
+    private final EmitterRepository emitterRepository;
+    private final NotificationRepository notificationRepository;
+
+    @Override
+    @Transactional
+    public SseEmitter subscribe(Long memberId, String lastEventId) {
+        String id = memberId + "_" + System.currentTimeMillis();
+        SseEmitter emitter = emitterRepository.save(id, new SseEmitter(DEFAULT_TIMEOUT));
+
+        emitter.onCompletion(() -> emitterRepository.deleteById(id));
+        emitter.onTimeout(() -> emitterRepository.deleteById(id));
+
+        // 503 에러를 방지하기 위한 더미 이벤트 전송
+        sendToClient(emitter, id, "EventStream Created. [memberId=" + memberId + "]");
+
+        // 클라이언트가 미수신한 Event 목록이 존재할 경우 전송하여 Event 유실을 예방
+        if (!lastEventId.isEmpty()) {
+            Map<String, Object> events = emitterRepository.findAllEventCacheStartWithId(
+                String.valueOf(memberId));
+            events.entrySet().stream()
+                .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                .forEach(entry -> sendToClient(emitter, entry.getKey(), entry.getValue()));
+        }
+
+        return emitter;
+    }
+
+    private void sendToClient(SseEmitter emitter, String id, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                .id(id)
+                .name("sse")
+                .data(data));
+        } catch (IOException exception) {
+            emitterRepository.deleteById(id);
+            log.error("SSE 연결 오류!", exception);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void send(Long senderId, Long receiverId) {
+        Notification notification = new Notification(senderId, receiverId);
+        String id = String.valueOf(receiverId);
+        notificationRepository.save(notification);
+        Map<String, SseEmitter> sseEmitters = emitterRepository.findAllStartWithById(id);
+        sseEmitters.forEach(
+            (key, emitter) -> {
+                emitterRepository.saveEventCache(key, notification);
+                sendToClient(emitter, key, NotificationResponseDto.from(notification));
+            }
+        );
+    }
+
+//    @Transactional
+//    public NotificationsResponse findAllById(LoginMember loginMember) {
+//        List<NotificationResponse> responses = notificationRepository.findAllByReceiverId(
+//                loginMember.getId()).stream()
+//            .map(NotificationResponse::from)
+//            .collect(Collectors.toList());
+//        long unreadCount = responses.stream()
+//            .filter(notification -> !notification.isRead())
+//            .count();
+//
+//        return NotificationsResponse.of(responses, unreadCount);
+//    }
+
+//    @Transactional
+//    public void readNotification(Long id) {
+//        Notification notification = notificationRepository.findById(id)
+//            .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 알림입니다."));
+//        notification.read();
+//    }
+}

--- a/src/main/java/ohho/backend/spring/domain/partner/controller/PartnerController.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/controller/PartnerController.java
@@ -1,0 +1,35 @@
+package ohho.backend.spring.domain.partner.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import ohho.backend.spring.common.ApiResponse;
+import ohho.backend.spring.domain.partner.entities.Partner;
+import ohho.backend.spring.domain.partner.model.request.UpdateDdayAndGoalRequest;
+import ohho.backend.spring.domain.partner.service.PartnerService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/partners")
+@RequiredArgsConstructor
+public class PartnerController {
+
+    private final PartnerService partnerService;
+
+    @GetMapping("/{id}")
+    public ApiResponse<Partner> getPartner(@PathVariable("id") Long id) {
+        return ApiResponse.success(partnerService.getPartner(id));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<String> updateDdayAndGoalRequest(
+        @PathVariable("id") Long id,
+        @RequestBody UpdateDdayAndGoalRequest updateDdayAndGoalRequest) {
+        return ApiResponse.success(partnerService.updateDdayAndGoal(id, updateDdayAndGoalRequest));
+    }
+
+}

--- a/src/main/java/ohho/backend/spring/domain/partner/controller/PartnerController.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/controller/PartnerController.java
@@ -4,11 +4,16 @@ package ohho.backend.spring.domain.partner.controller;
 import lombok.RequiredArgsConstructor;
 import ohho.backend.spring.common.ApiResponse;
 import ohho.backend.spring.domain.partner.entities.Partner;
-import ohho.backend.spring.domain.partner.model.request.UpdateDdayAndGoalRequest;
+import ohho.backend.spring.domain.partner.exception.PartnerNotFoundException;
+import ohho.backend.spring.domain.partner.model.request.AcceptPartnerRequestDto;
+import ohho.backend.spring.domain.partner.model.request.RequestPartnerRequestDto;
+import ohho.backend.spring.domain.partner.model.request.UpdateDdayAndGoalRequestDto;
 import ohho.backend.spring.domain.partner.service.PartnerService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +25,20 @@ public class PartnerController {
 
     private final PartnerService partnerService;
 
+    @PostMapping("/request")
+    public ApiResponse<String> requestPartner(@ModelAttribute("memberId") Long memberId,
+        @RequestBody RequestPartnerRequestDto requestPartnerRequestDto) {
+        return ApiResponse.success(
+            partnerService.requestPartner(memberId, requestPartnerRequestDto));
+    }
+
+    @PostMapping("/accept")
+    public ApiResponse<Partner> acceptPartner(@ModelAttribute("memberId") Long memberId,
+        @RequestBody AcceptPartnerRequestDto acceptPartnerRequestDto) {
+        return ApiResponse.success(
+            partnerService.acceptPartner(memberId, acceptPartnerRequestDto));
+    }
+
     @GetMapping("/{id}")
     public ApiResponse<Partner> getPartner(@PathVariable("id") Long id) {
         return ApiResponse.success(partnerService.getPartner(id));
@@ -28,7 +47,7 @@ public class PartnerController {
     @PatchMapping("/{id}")
     public ApiResponse<String> updateDdayAndGoalRequest(
         @PathVariable("id") Long id,
-        @RequestBody UpdateDdayAndGoalRequest updateDdayAndGoalRequest) {
+        @RequestBody UpdateDdayAndGoalRequestDto updateDdayAndGoalRequest) {
         return ApiResponse.success(partnerService.updateDdayAndGoal(id, updateDdayAndGoalRequest));
     }
 

--- a/src/main/java/ohho/backend/spring/domain/partner/entities/Partner.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/entities/Partner.java
@@ -6,15 +6,12 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import ohho.backend.spring.common.entities.BaseEntity;
 import ohho.backend.spring.domain.member.entities.Member;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Partner extends BaseEntity {
 
     private LocalDate dDay;
@@ -25,4 +22,8 @@ public class Partner extends BaseEntity {
 
     @OneToMany(mappedBy = "partner", cascade = CascadeType.ALL)
     private List<Member> members = new ArrayList<>();
+
+    public void addMember(Member member) {
+        this.members.add(member);
+    }
 }

--- a/src/main/java/ohho/backend/spring/domain/partner/exception/PartnerNotFoundException.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/exception/PartnerNotFoundException.java
@@ -1,0 +1,12 @@
+package ohho.backend.spring.domain.partner.exception;
+
+import ohho.backend.spring.common.ResultCode;
+import ohho.backend.spring.common.exception.NotFoundException;
+
+public class PartnerNotFoundException extends NotFoundException {
+
+    public PartnerNotFoundException() {
+        super(ResultCode.PARTNER_NOT_FOUND);
+    }
+}
+

--- a/src/main/java/ohho/backend/spring/domain/partner/model/request/AcceptPartnerRequestDto.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/model/request/AcceptPartnerRequestDto.java
@@ -1,0 +1,9 @@
+package ohho.backend.spring.domain.partner.model.request;
+
+import lombok.Data;
+
+@Data
+public class AcceptPartnerRequestDto {
+
+    private long senderId;
+}

--- a/src/main/java/ohho/backend/spring/domain/partner/model/request/RequestPartnerRequestDto.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/model/request/RequestPartnerRequestDto.java
@@ -1,0 +1,9 @@
+package ohho.backend.spring.domain.partner.model.request;
+
+import lombok.Data;
+
+@Data
+public class RequestPartnerRequestDto {
+
+    private long receiverId;
+}

--- a/src/main/java/ohho/backend/spring/domain/partner/model/request/UpdateDdayAndGoalRequest.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/model/request/UpdateDdayAndGoalRequest.java
@@ -1,0 +1,11 @@
+package ohho.backend.spring.domain.partner.model.request;
+
+import java.time.LocalDate;
+import lombok.Data;
+
+@Data
+public class UpdateDdayAndGoalRequest {
+
+    private LocalDate dDay;
+    private String goal;
+}

--- a/src/main/java/ohho/backend/spring/domain/partner/model/request/UpdateDdayAndGoalRequestDto.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/model/request/UpdateDdayAndGoalRequestDto.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import lombok.Data;
 
 @Data
-public class UpdateDdayAndGoalRequest {
+public class UpdateDdayAndGoalRequestDto {
 
     private LocalDate dDay;
     private String goal;

--- a/src/main/java/ohho/backend/spring/domain/partner/repository/PartnerCustomRepository.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/repository/PartnerCustomRepository.java
@@ -1,0 +1,8 @@
+package ohho.backend.spring.domain.partner.repository;
+
+import java.time.LocalDate;
+
+public interface PartnerCustomRepository {
+
+    Long updateDdayAndGoal(Long id, LocalDate dDay, String goal);
+}

--- a/src/main/java/ohho/backend/spring/domain/partner/repository/PartnerCustomRepositoryImpl.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/repository/PartnerCustomRepositoryImpl.java
@@ -1,0 +1,39 @@
+package ohho.backend.spring.domain.partner.repository;
+
+import static ohho.backend.spring.domain.partner.entities.QPartner.partner;
+
+import com.querydsl.core.dml.UpdateClause;
+import com.querydsl.core.util.StringUtils;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.jpa.impl.JPAUpdateClause;
+import java.time.LocalDate;
+import javax.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.ObjectUtils;
+
+@Repository
+public class PartnerCustomRepositoryImpl implements PartnerCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public PartnerCustomRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Long updateDdayAndGoal(Long id, LocalDate dDay, String goal) {
+        UpdateClause<JPAUpdateClause> updateClauseUpdateClause = queryFactory.update(partner);
+
+        if (!ObjectUtils.isEmpty(dDay)) {
+            updateClauseUpdateClause.set(partner.dDay, dDay);
+        }
+
+        if (!StringUtils.isNullOrEmpty(goal)) {
+            updateClauseUpdateClause.set(partner.goal, goal);
+        }
+
+        return updateClauseUpdateClause
+            .where(partner.id.eq(id))
+            .execute();
+    }
+}

--- a/src/main/java/ohho/backend/spring/domain/partner/repository/PartnerRepository.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/repository/PartnerRepository.java
@@ -1,0 +1,8 @@
+package ohho.backend.spring.domain.partner.repository;
+
+import ohho.backend.spring.domain.partner.entities.Partner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PartnerRepository extends JpaRepository<Partner, Long>, PartnerCustomRepository {
+
+}

--- a/src/main/java/ohho/backend/spring/domain/partner/service/PartnerService.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/service/PartnerService.java
@@ -1,11 +1,17 @@
 package ohho.backend.spring.domain.partner.service;
 
 import ohho.backend.spring.domain.partner.entities.Partner;
-import ohho.backend.spring.domain.partner.model.request.UpdateDdayAndGoalRequest;
+import ohho.backend.spring.domain.partner.model.request.AcceptPartnerRequestDto;
+import ohho.backend.spring.domain.partner.model.request.RequestPartnerRequestDto;
+import ohho.backend.spring.domain.partner.model.request.UpdateDdayAndGoalRequestDto;
 
 public interface PartnerService {
 
+    String requestPartner(Long senderId, RequestPartnerRequestDto requestPartnerRequestDto);
+
+    Partner acceptPartner(Long requestId, AcceptPartnerRequestDto acceptPartnerRequestDto);
+
     Partner getPartner(Long partnerId);
 
-    String updateDdayAndGoal(Long id, UpdateDdayAndGoalRequest updateDdayAndGoalRequest);
+    String updateDdayAndGoal(Long id, UpdateDdayAndGoalRequestDto updateDdayAndGoalRequest);
 }

--- a/src/main/java/ohho/backend/spring/domain/partner/service/PartnerService.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/service/PartnerService.java
@@ -1,0 +1,11 @@
+package ohho.backend.spring.domain.partner.service;
+
+import ohho.backend.spring.domain.partner.entities.Partner;
+import ohho.backend.spring.domain.partner.model.request.UpdateDdayAndGoalRequest;
+
+public interface PartnerService {
+
+    Partner getPartner(Long partnerId);
+
+    String updateDdayAndGoal(Long id, UpdateDdayAndGoalRequest updateDdayAndGoalRequest);
+}

--- a/src/main/java/ohho/backend/spring/domain/partner/service/PartnerServiceImpl.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/service/PartnerServiceImpl.java
@@ -2,10 +2,17 @@ package ohho.backend.spring.domain.partner.service;
 
 import lombok.RequiredArgsConstructor;
 
+import ohho.backend.spring.domain.member.entities.Member;
+import ohho.backend.spring.domain.member.exception.MemberNotFoundException;
+import ohho.backend.spring.domain.member.repository.MemberRepository;
+import ohho.backend.spring.domain.notification.service.NotificationService;
 import ohho.backend.spring.domain.partner.entities.Partner;
 import ohho.backend.spring.domain.partner.exception.PartnerNotFoundException;
-import ohho.backend.spring.domain.partner.model.request.UpdateDdayAndGoalRequest;
+import ohho.backend.spring.domain.partner.model.request.AcceptPartnerRequestDto;
+import ohho.backend.spring.domain.partner.model.request.RequestPartnerRequestDto;
+import ohho.backend.spring.domain.partner.model.request.UpdateDdayAndGoalRequestDto;
 import ohho.backend.spring.domain.partner.repository.PartnerRepository;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -16,6 +23,29 @@ import org.springframework.util.Assert;
 public class PartnerServiceImpl implements PartnerService {
 
     private final PartnerRepository partnerRepository;
+    private final MemberRepository memberRepository;
+    private final NotificationService notificationService;
+
+    @Override
+    public String requestPartner(Long senderId,
+        RequestPartnerRequestDto requestPartnerRequestDto) {
+        notificationService.send(senderId, requestPartnerRequestDto.getReceiverId());
+        return "파트너 요청이 성공적으로 완료되었습니다.";
+    }
+
+    @Override
+    public Partner acceptPartner(Long requestId,
+        AcceptPartnerRequestDto acceptPartnerRequestDto) {
+        Member member1 = memberRepository.findById(requestId)
+            .orElseThrow(MemberNotFoundException::new);
+        Member member2 = memberRepository.findById(acceptPartnerRequestDto.getSenderId())
+            .orElseThrow(MemberNotFoundException::new);
+        Partner partner = new Partner();
+        partner.addMember(member1);
+        partner.addMember(member2);
+        partnerRepository.save(partner);
+        return partner;
+    }
 
     @Override
     public Partner getPartner(Long partnerId) {
@@ -26,7 +56,7 @@ public class PartnerServiceImpl implements PartnerService {
 
     @Override
     @Transactional
-    public String updateDdayAndGoal(Long id, UpdateDdayAndGoalRequest updateDdayAndGoalRequest) {
+    public String updateDdayAndGoal(Long id, UpdateDdayAndGoalRequestDto updateDdayAndGoalRequest) {
         partnerRepository.updateDdayAndGoal(id, updateDdayAndGoalRequest.getDDay(),
             updateDdayAndGoalRequest.getGoal());
         return "업데이트가 완료되었습니다.";

--- a/src/main/java/ohho/backend/spring/domain/partner/service/PartnerServiceImpl.java
+++ b/src/main/java/ohho/backend/spring/domain/partner/service/PartnerServiceImpl.java
@@ -1,0 +1,34 @@
+package ohho.backend.spring.domain.partner.service;
+
+import lombok.RequiredArgsConstructor;
+
+import ohho.backend.spring.domain.partner.entities.Partner;
+import ohho.backend.spring.domain.partner.exception.PartnerNotFoundException;
+import ohho.backend.spring.domain.partner.model.request.UpdateDdayAndGoalRequest;
+import ohho.backend.spring.domain.partner.repository.PartnerRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PartnerServiceImpl implements PartnerService {
+
+    private final PartnerRepository partnerRepository;
+
+    @Override
+    public Partner getPartner(Long partnerId) {
+        Assert.notNull(partnerId, "'partnerId' must not be null");
+        return partnerRepository.findById(partnerId)
+            .orElseThrow(PartnerNotFoundException::new);
+    }
+
+    @Override
+    @Transactional
+    public String updateDdayAndGoal(Long id, UpdateDdayAndGoalRequest updateDdayAndGoalRequest) {
+        partnerRepository.updateDdayAndGoal(id, updateDdayAndGoalRequest.getDDay(),
+            updateDdayAndGoalRequest.getGoal());
+        return "업데이트가 완료되었습니다.";
+    }
+}


### PR DESCRIPTION
## 변경사항

### 로그인한 멤버 SSE 연결 API
- 현재는 MySQL을 활용하여 SSE 구현하였습니다.

### 서비스 내에서 운동을 함께할 파트너 요청 API
- 파트너 맺고 싶은 사용자의 닉네임 검색
- 사용자에게 파트너 요청

### 파트너 수락 API

### 파트너 정보 API

### 디데이 및 목표 설정 및 업데이트 API
- 파트너 요청이 완료되었다는 가정 하에 수행